### PR TITLE
new option repserver --stat

### DIFF
--- a/cmd/repserver/handlers/fetch.go
+++ b/cmd/repserver/handlers/fetch.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/repbin/repbin/cmd/repserver/stat"
 	log "github.com/repbin/repbin/deferconsole"
 	"github.com/repbin/repbin/message"
 	"github.com/repbin/repbin/utils"
@@ -55,5 +56,8 @@ func (ms MessageServer) Fetch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	log.Debugs("Fetch OK\n")
+	if ms.Stat {
+		stat.Input <- stat.Fetch
+	}
 	return
 }

--- a/cmd/repserver/handlers/post.go
+++ b/cmd/repserver/handlers/post.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/repbin/repbin/cmd/repserver/stat"
 	log "github.com/repbin/repbin/deferconsole"
 	"github.com/repbin/repbin/message"
 	"github.com/repbin/repbin/utils"
@@ -88,6 +89,9 @@ func (ms MessageServer) ProcessPost(postdata io.ReadCloser, oneTime bool, expire
 		return fmt.Sprintf("ERROR: %s\n", err)
 	}
 	log.Debugf("Post:Added: %x\n", MessageID[:12])
+	if ms.Stat {
+		stat.Input <- stat.Post
+	}
 	return "SUCCESS: Connection close\n"
 }
 

--- a/cmd/repserver/handlers/run.go
+++ b/cmd/repserver/handlers/run.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/repbin/repbin/cmd/repserver/stat"
 	log "github.com/repbin/repbin/deferconsole"
 )
 
@@ -23,6 +24,10 @@ func (ms MessageServer) RunServer() {
 	ms.notifyChan = make(chan bool, 3)
 	// Load peers
 	ms.LoadPeers()
+	// Start statistics goroutine
+	if ms.Stat {
+		go stat.Run()
+	}
 	// Start timers
 	go ms.notifyWatch()
 	// static file handler

--- a/cmd/repserver/handlers/server.go
+++ b/cmd/repserver/handlers/server.go
@@ -104,8 +104,9 @@ type MessageServer struct {
 	HubOnly              bool      // should this server act only as hub?
 	StepLimit            int       // Boost limit
 	ListenPort           int       // what port to listen on for http
-	MinStoreTime         int       //minimum time in seconds for storage
+	MinStoreTime         int       // minimum time in seconds for storage
 	MaxStoreTime         int       // maximum time in seconds for storage
+	Stat                 bool      // calculate and show server usage statistics
 	notifyChan           chan bool // Notification channel. Write to notify system about new message
 }
 

--- a/cmd/repserver/repserver.go
+++ b/cmd/repserver/repserver.go
@@ -23,7 +23,10 @@ import (
 // Version of this release
 const Version = "0.0.1 very alpha"
 
-var start *bool
+var (
+	start *bool
+	stat  *bool
+)
 
 func init() {
 	version := flag.Bool("version", false, "Print version information")
@@ -31,6 +34,7 @@ func init() {
 	configfile := flag.String("configfile", "", "Path to configuration file")
 	verbose := flag.Bool("verbose", false, "Show some verbose output")
 	start = flag.Bool("start", false, "Start server")
+	stat = flag.Bool("stat", false, "Enable usage statistics")
 	flag.Parse()
 	if *version {
 		fmt.Printf("Repserver: %s\n", Version)
@@ -57,6 +61,10 @@ func init() {
 	}
 	if *verbose {
 		log.SetMinLevel(log.LevelDebug)
+	}
+	if *stat && !*verbose {
+		fmt.Println("Error: option --stat requires option --verbose")
+		os.Exit(1)
 	}
 	err := loadConfig(*configfile)
 	if err != nil {
@@ -88,6 +96,7 @@ func main() {
 		os.Exit(1)
 	}
 	applyConfig(ms)
+	ms.Stat = *stat
 	if *start {
 		ms.RunServer()
 	} else {

--- a/cmd/repserver/stat/stat.go
+++ b/cmd/repserver/stat/stat.go
@@ -1,0 +1,89 @@
+// Package stat gathers and prints repbin server usage statistics.
+// Post and fetch statistics are shown as minute-by-minute averages over the
+// last minute, 5 minutes, 60 minutes and 24 hours.
+package stat
+
+import (
+	"container/list"
+	"time"
+
+	log "github.com/repbin/repbin/deferconsole"
+)
+
+// Event describes the stat event send to the input channel.
+type Event int
+
+const (
+	// Post adds a new post to the statistic.
+	Post = iota
+	// Fetch adds a new fetch to the statistic.
+	Fetch
+	// Show prints the statistics.
+	Show
+)
+
+// Input is the repserver statistics input channel.
+var Input = make(chan Event, 1024)
+
+func now() int64 {
+	return time.Now().UTC().Unix()
+}
+
+func removeOld(l *list.List, cutoff int64) {
+	e := l.Front()
+	for e != nil {
+		if e.Value.(int64) <= cutoff {
+			l.Remove(e)
+			e = l.Front()
+		} else {
+			break
+		}
+	}
+}
+
+// Run starts the statistics handler.
+func Run() {
+	postList1 := list.New()
+	postList5 := list.New()
+	postList60 := list.New()
+	postList1440 := list.New()
+	fetchList1 := list.New()
+	fetchList5 := list.New()
+	fetchList60 := list.New()
+	fetchList1440 := list.New()
+	for {
+		m := <-Input
+		t := now()
+		switch m {
+		case Post:
+			postList1.PushBack(t)
+			postList5.PushBack(t)
+			postList60.PushBack(t)
+			postList1440.PushBack(t)
+		case Fetch:
+			fetchList1.PushBack(t)
+			fetchList5.PushBack(t)
+			fetchList60.PushBack(t)
+			fetchList1440.PushBack(t)
+		case Show:
+			removeOld(postList1, t-1*60)
+			removeOld(postList5, t-5*60)
+			removeOld(postList60, t-60*60)
+			removeOld(postList1440, t-1440*60)
+			removeOld(fetchList1, t-1*60)
+			removeOld(fetchList5, t-5*60)
+			removeOld(fetchList60, t-60*60)
+			removeOld(fetchList1440, t-1440*60)
+			log.Debugf("Posts/minute:   %8.3f (1m) %8.3f (5m) %8.3f (1h) %8.3f (24h)\n",
+				float64(postList1.Len()),
+				float64(postList5.Len())/5.0,
+				float64(postList60.Len())/60.0,
+				float64(postList1440.Len())/1440.0)
+			log.Debugf("Fetches/minute: %8.3f (1m) %8.3f (5m) %8.3f (1h) %8.3f (24h)\n",
+				float64(fetchList1.Len()),
+				float64(fetchList5.Len())/5.0,
+				float64(fetchList60.Len())/60.0,
+				float64(fetchList1440.Len())/1440.0)
+		}
+	}
+}


### PR DESCRIPTION
Post and fetch statistics are shown as minute-by-minute averages over the last minute, 5 minutes, 60 minutes and 24 hours.